### PR TITLE
Add buttons to clear layers and download

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,23 +1,109 @@
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
-import React from 'react'
-import styled from 'styled-components'
+import styled, { ThemeContext } from 'styled-components'
+import { ArrowLoop, Download } from '../icons'
 
 import Header from './Header'
 
 const Container = styled.section`
   grid-column: 1 / span 3;
 
-  height: 100%;
+  height: 100vh;
   box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.24);
   z-index: 1;
-  overflow-y: scroll;
+
+  display: flex;
+  flex-direction: column;
 `
 
-export default function Drawer({ siteName, country, cc, children }) {
+const ScrollContainer = styled.div`
+  flex-grow: 1;
+  overflow-y: scroll;
+
+  border-top: ${({ theme }) => `1px solid ${theme.colors.accent}`};
+`
+
+const Actions = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding: ${({ theme }) => `${theme.space[3]}px`};
+  gap: ${({ theme }) => `${theme.space[3]}px`};
+`
+
+const PrimaryButton = styled.button`
+  cursor: ${({ disabled }) => (disabled ? `default` : `pointer`)};
+  text-decoration: none;
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  padding: ${({ theme }) => `${theme.space[2]}px ${theme.space[3]}px`};
+  border-color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.offtext : theme.colors.primary};
+  border-style: solid;
+  border-width: 2px;
+  border-radius: 4px;
+
+  background-color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.muted : theme.colors.primary};
+  color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.offtext : theme.colors.background};
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes[2]}pt;
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+`
+
+const SecondaryButton = styled(PrimaryButton)`
+  background-color: ${({ theme }) => theme.colors.background};
+  color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.offtext : theme.colors.primary};
+`
+
+const IconContainer = styled.span`
+  margin-right: ${({ theme }) => `${theme.space[2]}px`};
+`
+export default function Drawer({
+  siteName,
+  country,
+  cc,
+  clearAll,
+  hasSelectedLayers,
+  children,
+}) {
+  const theme = useContext(ThemeContext)
+
   return (
     <Container>
       <Header siteName={siteName} country={country} cc={cc} />
-      {children}
+      <ScrollContainer>{children}</ScrollContainer>
+      {hasSelectedLayers && (
+        <Actions>
+          <SecondaryButton
+            onClick={clearAll}
+            disabled={!hasSelectedLayers}
+            data-cy='clear-button'
+          >
+            <IconContainer aria-hidden='true'>
+              <ArrowLoop
+                color={
+                  hasSelectedLayers
+                    ? theme.colors.primary
+                    : theme.colors.offtext
+                }
+              />
+            </IconContainer>
+            Clear selection
+          </SecondaryButton>
+          <PrimaryButton
+            onClick={() => console.log('download not implemented')}
+            data-cy='download-button'
+          >
+            <IconContainer aria-hidden='true'>
+              <Download color={theme.colors.background} />
+            </IconContainer>
+            Download
+          </PrimaryButton>
+        </Actions>
+      )}
     </Container>
   )
 }
@@ -26,5 +112,7 @@ Drawer.propTypes = {
   siteName: PropTypes.string.isRequired,
   country: PropTypes.string.isRequired,
   cc: PropTypes.string.isRequired,
+  hasSelectedLayers: PropTypes.bool.isRequired,
+  clearAll: PropTypes.func.isRequired,
   children: PropTypes.element,
 }

--- a/src/config/theme.js
+++ b/src/config/theme.js
@@ -19,5 +19,5 @@ export default {
     heading: 700,
     bold: 700,
   },
-  space: [0, 4, 8, 16, 32, 70, 347],
+  space: [0, 4, 8, 16, 32, 70],
 }

--- a/src/icons/ArrowLoop.js
+++ b/src/icons/ArrowLoop.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ArrowLoop = ({ color = 'none' }) => (
+  <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'>
+    <path fill='none' d='M0 0h16v16H0z' />
+    <path
+      fill={color}
+      d='M6 4H3.528c.075-.081.15-.162.228-.244C4.891 2.625 6.397 2 8 2s3.109.625 4.244 1.756A5.974 5.974 0 0114 8h2a8 8 0 00-8-8 7.975 7.975 0 00-6 2.709V0H0v6h6V4zm4 8h2.472c-.075.081-.15.163-.228.244C11.109 13.375 9.603 14 8 14s-3.109-.625-4.244-1.756A5.974 5.974 0 012 8H0a8 8 0 008 8 7.975 7.975 0 006-2.709V16h2v-6h-6v2z'
+    />
+  </svg>
+)
+
+export default ArrowLoop
+
+ArrowLoop.propTypes = {
+  color: PropTypes.string,
+}

--- a/src/icons/Download.js
+++ b/src/icons/Download.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Download = ({ color = 'none' }) => (
+  <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'>
+    <path fill='none' d='M0 0h16v16H0z' />
+    <path
+      fill={color}
+      d='M12.706 8.294L11.29 6.878 9 9.172V0H7v9.172L4.706 6.878 3.291 8.294 8 13l4.706-4.706zM16 14H0v2h16v-2z'
+    />
+  </svg>
+)
+
+export default Download
+
+Download.propTypes = {
+  color: PropTypes.string,
+}

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -2,8 +2,10 @@ import Home from './Home'
 import Layers from './Layers'
 import Info from './Info'
 
+import ArrowLoop from './ArrowLoop'
 import ChevronDown from './ChevronDown'
 import ChevronUp from './ChevronUp'
+import Download from './Download'
 import InfoSmall from './InfoSmall'
 import Minus from './Minus'
 import Plus from './Plus'
@@ -20,8 +22,10 @@ export {
   Home,
   Layers,
   Info,
+  ArrowLoop,
   ChevronDown,
   ChevronUp,
+  Download,
   InfoSmall,
   Minus,
   Plus,

--- a/src/pages/Explore.js
+++ b/src/pages/Explore.js
@@ -101,6 +101,13 @@ export default function Explore({ siteAcronym, siteName, config, theme }) {
   const changeSlider = (payload) => {
     dispatch({ type: 'setSlider', payload })
   }
+  const clearAll = () => {
+    dispatch({ type: 'reset', payload: uicontrols })
+  }
+
+  const hasSelectedLayers = Object.values(state).some(
+    (control) => control.visibility
+  )
 
   return (
     <PageLayout siteAcronym={siteAcronym} theme={theme} noMargin>
@@ -108,6 +115,8 @@ export default function Explore({ siteAcronym, siteName, config, theme }) {
         siteName={siteName}
         country={config.country}
         cc={config.countryCode}
+        clearAll={clearAll}
+        hasSelectedLayers={hasSelectedLayers}
       >
         <LayerControl
           uiState={state}


### PR DESCRIPTION
Adds buttons to clear layers and download. The download button has no functionality yet.
The buttons will only appear and be clickable once at least one layer is selected.
Further design improvements: Header and buttons stay fixed while only layer panel is scrollable.