### PR TITLE
Move layers below labels

### DIFF
--- a/src/pages/Explore.js
+++ b/src/pages/Explore.js
@@ -142,6 +142,7 @@ export default function Explore({ siteAcronym, siteName, config, theme }) {
                       id={layer.id}
                       isVisible={state[controlId].visibility}
                       spec={layer}
+                      before='road-label' // This is a layer id from the basemap. It might not exist in other basemaps styles!
                     />
                   )
                 })}


### PR DESCRIPTION
It was hard to read the name of counties and cities below the density map. This change moves all layers below the basemap's labels. Within the set of defined layers, the order is just as in the config file (currently, `population-density` below `education`, and so on).